### PR TITLE
s/response/request

### DIFF
--- a/step-by-step/4-testing.md
+++ b/step-by-step/4-testing.md
@@ -50,7 +50,7 @@ pronounce it. To make changes to her pronunciation, use Speech Synthesis Markup 
     * If you receive a response that reads: *"The remote endpoint could not be called, or the response it returned was invalid,"* this is an indication that something is broken.  AWS Lambda offers an additional testing tool to help you troubleshoot your skill.
 
 5.  **Configure a test event in AWS Lambda.** Now that you are familiar with the **request** and **response** boxes in the Service Simulator, it's important for you to know that you can use your **requests** to directly test your Lambda function every time you update it.  To do this:
-    1.  Create & copy a new response with the Service Simulator, or grab the sample text from the box below:
+    1.  Create & copy a new request with the Service Simulator, or grab the sample text from the box below:
 
         ```JAVASCRIPT
         {


### PR DESCRIPTION
Based on the snippet to copy/paste, looks like this should be "request" rather than "response". PRing the fix to avoid confusion.